### PR TITLE
expressions fixes + implemented exceptions

### DIFF
--- a/public/bars.js
+++ b/public/bars.js
@@ -182,15 +182,13 @@ function tooltipImages() {
     var dialogueHeads = document.getElementsByClassName("dialogue-head"); // get all dialogue heads
 
     for (headIndex in dialogueHeads) { // for every dialogue head
-
-        // if this item is an object, and if it has an expression, and if it isn't an exception
-        // (everything SHOULD be an object but for some reason javascript is weird and puts non-objects in there. idk this stopped it throwing errors)
+        
         if (
-            typeof dialogueHeads[headIndex] == "object"
+            typeof dialogueHeads[headIndex] == "object" // is it an object
+            && // (everything SHOULD be an object but for some reason javascript is weird and puts non-objects in there. idk this stopped it throwing errors)
+            dialogueHeads[headIndex].getElementsByClassName("dialogue-expression")[0] // does it have an expression
             &&
-            dialogueHeads[headIndex].getElementsByClassName("dialogue-expression")[0]
-            &&
-            !(dialogueHeads[headIndex].getElementsByClassName("expression-exception")[0])
+            !(dialogueHeads[headIndex].getElementsByClassName("expression-exception")[0]) // is it NOT an exception
         ) {
 
             var nameElement = dialogueHeads[headIndex].getElementsByClassName("dialogue-name")[0] // get the dialogue name
@@ -198,7 +196,7 @@ function tooltipImages() {
 
             var nameReference;
 
-            if (typeof dialogueHeads[headIndex].getElementsByClassName("sasasap")[0] != "undefined") {
+            if (typeof dialogueHeads[headIndex].getElementsByClassName("sasasap")[0] != "undefined") { // is it a sasasap exception
 
                 if (nameElement.innerHTML == "Siffrin") {
                     nameReference = "Sapfrin";
@@ -213,21 +211,21 @@ function tooltipImages() {
                 }
                 if (debugMode) {console.log(`exception found: name is ${nameElement.innerHTML}, but head ${headIndex} should be referencing ${nameReference}`)};
 
-            } else if (typeof dialogueHeads[headIndex].getElementsByClassName("expression-exception-loop")[0] != "undefined") {
+            } else if (typeof dialogueHeads[headIndex].getElementsByClassName("expression-exception-loop")[0] != "undefined") { // should it be loop
 
                 nameReference = "Loop";
                 if (debugMode) {console.log(`exception found: name is ${nameElement.innerHTML}, but head ${headIndex} should be referencing ${nameReference}`)};
 
-            } else if (typeof dialogueHeads[headIndex].getElementsByClassName("expression-exception-siffrin")[0] != "undefined") {
+            } else if (typeof dialogueHeads[headIndex].getElementsByClassName("expression-exception-siffrin")[0] != "undefined") { // should it be siffrin
 
                 nameReference = "Siffrin";
                 if (debugMode) {console.log(`exception found: name is ${nameElement.innerHTML}, but head ${headIndex} should be referencing ${nameReference}`)};
                 
-            } else {
+            } else { // okay it's just normal then
                 nameReference = nameElement.innerHTML;
             }
 
-            // get the text
+            // get the expression text
             var expression = expressionElement.innerHTML; // same as the expression text
             var expression = expression.replace(/\((.+)\)/i, "$1"); // remove the parentheses
             
@@ -236,7 +234,7 @@ function tooltipImages() {
             var tooltip = expressionElement.firstElementChild; // get that span we just made
             tooltip.classList.add("tooltip"); // give it the tooltip class
 
-            var imageSrc = false;
+            var imageSrc = false; // declaring variable. if we don't get an image, this stays false
 
             switch (nameReference) {
 
@@ -2032,12 +2030,12 @@ function tooltipImages() {
                     break;
             }
 
-            if (imageSrc) {
-                dialogueImage = document.createElement("img");
-                dialogueImage.src = imageSrc;
-                tooltip.appendChild(dialogueImage);
-            } else {
-                tooltip.innerHTML = "image not found";
+            if (imageSrc) { // we got an image
+                dialogueImage = document.createElement("img"); // make an image
+                dialogueImage.src = imageSrc; // give it a source
+                tooltip.appendChild(dialogueImage); // put it in the tooltip
+            } else { // we didn't get an image
+                tooltip.innerHTML = "image not found"; // make the tooltip say that
             }
 
         }

--- a/public/bars.js
+++ b/public/bars.js
@@ -115,11 +115,11 @@ function toggleExpressions() {
         if (things[i].style.display === "none") {
             things[i].style.display = "inline-flex";
             sessionStorage.setItem("expressionsToggle", "on");
-            if (debugMode) {console.log("expressions on!");};
+            if (debugMode) {console.log("expressions on!")};
         } else {
             things[i].style.display = "none";
             sessionStorage.setItem("expressionsToggle", "off");
-            if (debugMode) {console.log("expressions off!");};
+            if (debugMode) {console.log("expressions off!")};
         }
     }
 }
@@ -137,9 +137,9 @@ window.onload = function() {
 
     if (sessionStorage.getItem("expressionsToggle") == "off") {
         toggleExpressions();
-        if (debugMode) {console.log("toggled expressions off on load!");};
+        if (debugMode) {console.log("toggled expressions off on load!")};
     } else {
-        if (debugMode) {console.log("expressions stayed on on load!");};
+        if (debugMode) {console.log("expressions stayed on on load!")};
     }
 };
 
@@ -162,11 +162,11 @@ function toggleDialogue() {
     for(var i = 0; i < details.length; i++) {
         if (details[i].open == true) {
             details[i].removeAttribute("open", "");
-            if (debugMode) {console.log("closed all dialogue options!");};
+            if (debugMode) {console.log("closed all dialogue options!")};
         }
         else {
             details[i].setAttribute("open", "");
-            if (debugMode) {console.log("opened all dialogue options!");};
+            if (debugMode) {console.log("opened all dialogue options!")};
         }
     }
 }
@@ -235,7 +235,7 @@ function tooltipImages() {
             switch (nameReference) {
 
                 case "Bonnie":
-                    if (debugMode) {console.log(nameElement, `head ${headIndex} is bonnie`);};
+                    if (debugMode) {console.log(nameElement, `head ${headIndex} is bonnie`)};
 
                     switch (expression) {
                         case "and then1":
@@ -392,14 +392,14 @@ function tooltipImages() {
                             imageSrc = "https://instarsandtime.wiki.gg/images/b/b1/ISAT_Portrait_Bonnie_Flabbergasted.png";
                             break;
                         default:
-                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for bonnie`);};
+                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for bonnie`)};
                             break;
                     }
 
                     break;
 
                 case "Euphrasie":
-                    if (debugMode) {console.log(nameElement, `head ${headIndex} is euphrasie`);};
+                    if (debugMode) {console.log(nameElement, `head ${headIndex} is euphrasie`)};
 
                     switch (expression) {
                         case "CRAB1":
@@ -457,14 +457,14 @@ function tooltipImages() {
                             imageSrc = "https://instarsandtime.wiki.gg/images/0/0a/ISAT_Portrait_Head_Housemaiden_Grateful_2.png";
                             break;
                         default:
-                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for euphrasie`);};
+                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for euphrasie`)};
                             break;
                     }
 
                     break;
 
                 case "Isabeau":
-                    if (debugMode) {console.log(nameElement, `head ${headIndex} is isabeau`);};
+                    if (debugMode) {console.log(nameElement, `head ${headIndex} is isabeau`)};
 
                     switch (expression) {
                         case "angry1":
@@ -666,19 +666,19 @@ function tooltipImages() {
                             imageSrc = "https://instarsandtime.wiki.gg/images/b/bc/ISAT_Portrait_Isabeau_Yeah.png";
                             break;
                         default:
-                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for isabeau`);};
+                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for isabeau`)};
                             break;
                     }
 
                     break;
 
                 case "King":
-                    if (debugMode) {console.log(nameElement, `head ${headIndex} is the king`);};
+                    if (debugMode) {console.log(nameElement, `head ${headIndex} is the king`)};
                     imageSrc = "https://instarsandtime.wiki.gg/images/a/a5/ISAT_Portrait_King.png";
                     break;
 
                 case "Loop":
-                    if (debugMode) {console.log(nameElement, `head ${headIndex} is loop`, expression);};
+                    if (debugMode) {console.log(nameElement, `head ${headIndex} is loop`, expression)};
 
                     switch (expression) {
                         case "angry1":
@@ -799,14 +799,14 @@ function tooltipImages() {
                             imageSrc = "https://instarsandtime.wiki.gg/images/b/b2/ISAT_Portrait_Loop_Well_4.png";
                             break;
                         default:
-                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for loop`);};
+                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for loop`)};
                             break;
                     }
 
                     break;
 
                 case "Mirabelle":
-                    if (debugMode) {console.log(nameElement, `head ${headIndex} is mirabelle`);};
+                    if (debugMode) {console.log(nameElement, `head ${headIndex} is mirabelle`)};
 
                     switch (expression) {
                         case "angry1":
@@ -972,14 +972,14 @@ function tooltipImages() {
                             imageSrc = "https://instarsandtime.wiki.gg/images/0/02/ISAT_Portrait_Mirabelle_Yelling.png";
                             break;
                         default:
-                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for mirabelle`);};
+                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for mirabelle`)};
                             break;
                     }
 
                     break;
 
                 case "Odile":
-                    if (debugMode) {console.log(nameElement, `head ${headIndex} is odile`);};
+                    if (debugMode) {console.log(nameElement, `head ${headIndex} is odile`)};
 
                     switch (expression) {
                         case "angry1":
@@ -1160,14 +1160,14 @@ function tooltipImages() {
                             imageSrc = "https://instarsandtime.wiki.gg/images/5/5d/ISAT_Portrait_Odile_Yeah.png";
                             break;
                         default:
-                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for odile`);};
+                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for odile`)};
                             break;
                     }
 
                     break;
 
                 case "Siffrin":
-                    if (debugMode) {console.log(nameElement, `head ${headIndex} is siffrin`);};
+                    if (debugMode) {console.log(nameElement, `head ${headIndex} is siffrin`)};
 
                     switch (expression) {
                         case "angry1":
@@ -1588,14 +1588,14 @@ function tooltipImages() {
                             imageSrc = "https://instarsandtime.wiki.gg/images/1/17/ISAT_Portrait_Siffrin_Yahoo_3_ACT6.png";
                             break;
                         default:
-                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for siffrin`);};
+                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for siffrin`)};
                             break;
                     }
 
                     break;
 
                 case "Fighter":
-                    if (debugMode) {console.log(nameElement, `head ${headIndex} is fighter`);};
+                    if (debugMode) {console.log(nameElement, `head ${headIndex} is fighter`)};
 
                     switch (expression) {
                         case "angry1":
@@ -1713,14 +1713,14 @@ function tooltipImages() {
                             imageSrc = "https://instarsandtime.wiki.gg/images/9/96/SASASAP_Portrait_Isabeau_Worried_4.png";
                             break;
                         default:
-                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for fighter`);};
+                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for fighter`)};
                             break;
                     }
 
                     break;
 
                 case "Housemaiden":
-                    if (debugMode) {console.log(nameElement, `head ${headIndex} is housemaiden`);};
+                    if (debugMode) {console.log(nameElement, `head ${headIndex} is housemaiden`)};
 
                     switch (expression) {
                         case "angry1":
@@ -1811,14 +1811,14 @@ function tooltipImages() {
                             imageSrc = "https://instarsandtime.wiki.gg/images/d/d4/SASASAP_Portrait_Mirabelle_Worried_3.png";
                             break;
                         default:
-                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for housemaiden`);};
+                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for housemaiden`)};
                             break;
                     }
 
                     break;
 
                 case "Kid":
-                    if (debugMode) {console.log(nameElement, `head ${headIndex} is kid`);};
+                    if (debugMode) {console.log(nameElement, `head ${headIndex} is kid`)};
 
                     switch (expression) {
                         case "angry1":
@@ -1891,14 +1891,14 @@ function tooltipImages() {
                             imageSrc = "https://instarsandtime.wiki.gg/images/5/53/SASASAP_Portrait_Bonnie_Amazed.png";
                             break;
                         default:
-                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for kid`);};
+                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for kid`)};
                             break;
                     }
 
                     break;
                 
                 case "Researcher":
-                    if (debugMode) {console.log(nameElement, `head ${headIndex} is researcher`);};
+                    if (debugMode) {console.log(nameElement, `head ${headIndex} is researcher`)};
 
                     switch (expression) {
                         case "angry1":
@@ -1956,14 +1956,14 @@ function tooltipImages() {
                             imageSrc = "https://instarsandtime.wiki.gg/images/1/14/SASASAP_Portrait_Odile_Worried_3.png";
                             break;
                         default:
-                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for researcher`);};
+                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for researcher`)};
                             break;
                     }
 
                     break;
                 
                 case "Sapfrin":
-                    if (debugMode) {console.log(nameElement, `head ${headIndex} is sapfrin`);};
+                    if (debugMode) {console.log(nameElement, `head ${headIndex} is sapfrin`)};
 
                     switch (expression) {
                         case "fake1":
@@ -2015,14 +2015,14 @@ function tooltipImages() {
                             imageSrc = "https://instarsandtime.wiki.gg/images/2/28/SASASAP_Portrait_Siffrin_Surprised_2.png";
                             break;
                         default:
-                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for sapfrin`);};
+                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for sapfrin`)};
                             break;
                     }
 
                     break;
 
                 default: 
-                    if (debugMode) {console.log(nameElement, `'${nameElement.innerHTML}' isn't a recognized name`);};
+                    if (debugMode) {console.log(nameElement, `'${nameElement.innerHTML}' isn't a recognized name`)};
                     break;
             }
 

--- a/public/bars.js
+++ b/public/bars.js
@@ -572,7 +572,7 @@ function tooltipImages() {
                         case "neutral2":
                             imageSrc = "https://instarsandtime.wiki.gg/images/4/46/ISAT_Portrait_Isabeau_Neutral_2.png";
                             break;
-                        case "no1":
+                        case "NO!1":
                             imageSrc = "https://instarsandtime.wiki.gg/images/e/ec/ISAT_Portrait_Isabeau_Weeping.png";
                             break;
                         case "oh1":
@@ -1287,7 +1287,7 @@ function tooltipImages() {
                         case "no1":
                             imageSrc = "https://instarsandtime.wiki.gg/images/c/c4/ISAT_Portrait_Siffrin_Emotional.png";
                             break;
-                        case "nya":
+                        case "nya1":
                             imageSrc = "https://instarsandtime.wiki.gg/images/6/65/ISAT_Portrait_Siffrin_Grin.png";
                             break;
                         case "okay1":

--- a/public/bars.js
+++ b/public/bars.js
@@ -110,39 +110,36 @@ function changeFontStyle(fontFamily) {
 // gold's expressions toggle code
 function toggleExpressions() {
     var things = document.getElementsByClassName("dialogue-expression");
-    var expressionsOff;
 
     for(var i = 0; i < things.length; i++) {
         if (things[i].style.display === "none") {
             things[i].style.display = "inline-flex";
-            expressionsOff = false;
+            sessionStorage.setItem("expressionsToggle", "on");
             if (debugMode) {console.log("expressions on!");};
         } else {
             things[i].style.display = "none";
-            expressionsOff = true;
+            sessionStorage.setItem("expressionsToggle", "off");
             if (debugMode) {console.log("expressions off!");};
         }
     }
-    sessionStorage.setItem("expressionsToggle", expressionsOff);
 }
 // end gold's expressions toggle code
 
 
 // load correct font if it had been set previously
 window.onload = function() {
-    // i don't think this works at all actually. i've never seen it do anything -gold
 
     var font = sessionStorage.getItem('font');
-    if(!!font) {
+    if (!!font) {
         changeFontStyle(font);
     }
 
     // gold's expressions toggle code
-    if(sessionStorage.getItem("expressionsToggle") == true) {
+    if (sessionStorage.getItem("expressionsToggle") == "off") {
         toggleExpressions();
-        if (debugMode) {console.log("toggled expressions on load!");};
+        if (debugMode) {console.log("toggled expressions off on load!");};
     } else {
-        if (debugMode) {console.log("expressions stayed the same on load!");};
+        if (debugMode) {console.log("expressions stayed on on load!");};
     }
     // end gold's expressions toggle code
 };

--- a/public/bars.js
+++ b/public/bars.js
@@ -1,4 +1,4 @@
-debugMode = true;
+debugMode = false;
 // change this to true and check console for debug logs!
 
 class Header extends HTMLElement {

--- a/public/bars.js
+++ b/public/bars.js
@@ -134,14 +134,12 @@ window.onload = function() {
         changeFontStyle(font);
     }
 
-    // gold's expressions toggle code
     if (sessionStorage.getItem("expressionsToggle") == "off") {
         toggleExpressions();
         if (debugMode) {console.log("toggled expressions off on load!");};
     } else {
         if (debugMode) {console.log("expressions stayed on on load!");};
     }
-    // end gold's expressions toggle code
 };
 
 // Feli's Button test corner

--- a/public/bars.js
+++ b/public/bars.js
@@ -1,4 +1,4 @@
-debugMode = false;
+debugMode = true;
 // change this to true and check console for debug logs!
 
 class Header extends HTMLElement {
@@ -196,7 +196,10 @@ function tooltipImages() {
             var nameElement = dialogueHeads[headIndex].getElementsByClassName("dialogue-name")[0] // get the dialogue name
             var expressionElement = dialogueHeads[headIndex].getElementsByClassName("dialogue-expression")[0]; // get the dialogue expression
 
-            if (dialogueHeads[headIndex].getElementsByClassName("sasasap")[0]) {
+            var nameReference;
+
+            if (typeof dialogueHeads[headIndex].getElementsByClassName("sasasap")[0] != "undefined") {
+
                 if (nameElement.innerHTML == "Siffrin") {
                     nameReference = "Sapfrin";
                 } else if (nameElement.innerHTML == "Isabeau") {
@@ -208,6 +211,18 @@ function tooltipImages() {
                 } else if (nameElement.innerHTML == "Odile") {
                     nameReference = "Researcher";
                 }
+                if (debugMode) {console.log(`exception found: name is ${nameElement.innerHTML}, but head ${headIndex} should be referencing ${nameReference}`)};
+
+            } else if (typeof dialogueHeads[headIndex].getElementsByClassName("expression-exception-loop")[0] != "undefined") {
+
+                nameReference = "Loop";
+                if (debugMode) {console.log(`exception found: name is ${nameElement.innerHTML}, but head ${headIndex} should be referencing ${nameReference}`)};
+
+            } else if (typeof dialogueHeads[headIndex].getElementsByClassName("expression-exception-siffrin")[0] != "undefined") {
+
+                nameReference = "Siffrin";
+                if (debugMode) {console.log(`exception found: name is ${nameElement.innerHTML}, but head ${headIndex} should be referencing ${nameReference}`)};
+                
             } else {
                 nameReference = nameElement.innerHTML;
             }
@@ -1947,7 +1962,7 @@ function tooltipImages() {
                             imageSrc = "https://instarsandtime.wiki.gg/images/1/14/SASASAP_Portrait_Odile_Worried_3.png";
                             break;
                         default:
-                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for odile`);};
+                            if (debugMode) {console.log(nameElement, `expression '${expression}' not found for researcher`);};
                             break;
                     }
 

--- a/public/bars.js
+++ b/public/bars.js
@@ -126,8 +126,9 @@ function toggleExpressions() {
 // end gold's expressions toggle code
 
 
-// load correct font if it had been set previously
 window.onload = function() {
+
+    tooltipImages();
 
     var font = sessionStorage.getItem('font');
     if (!!font) {
@@ -2036,5 +2037,3 @@ function tooltipImages() {
         }
     }
 }
-
-tooltipImages();

--- a/public/rooms/dormont/favortree.html
+++ b/public/rooms/dormont/favortree.html
@@ -496,7 +496,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">???</span>
+            <span class="dialogue-name expression-exception-loop">???</span>
             <span class="dialogue-expression">(subdued1)</span>
         </span>
         ...
@@ -512,7 +512,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">???</span>
+            <span class="dialogue-name expression-exception-loop">???</span>
             <span class="dialogue-expression">(subdued1)</span>
         </span>
         ...
@@ -528,7 +528,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">???</span>
+            <span class="dialogue-name expression-exception-loop">???</span>
             <span class="dialogue-expression">(lol1)</span>
         </span>
         My, struck speechless at the sight of me, aren't you?
@@ -536,7 +536,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">???</span>
+            <span class="dialogue-name expression-exception-loop">???</span>
             <span class="dialogue-expression">(lol1)</span>
         </span>
         You're so cute, stardust!
@@ -551,7 +551,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">???</span>
+            <span class="dialogue-name expression-exception-loop">???</span>
             <span class="dialogue-expression">(lol3)</span>
         </span>
         Aw, Siffrin, look at you. All lost and confused.
@@ -567,7 +567,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">???</span>
+            <span class="dialogue-name expression-exception-loop">???</span>
             <span class="dialogue-expression">(happy2)</span>
         </span>
         Why wouldn't I know? You're Sif! Siffrin!
@@ -575,7 +575,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">???</span>
+            <span class="dialogue-name expression-exception-loop">???</span>
             <span class="dialogue-expression">(well3)</span>
         </span>
         No middle names, no last name! Just Siffrin!
@@ -583,7 +583,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">???</span>
+            <span class="dialogue-name expression-exception-loop">???</span>
             <span class="dialogue-expression">(hmmm1)</span>
         </span>
         I shouldn't wonder why you look like this, though. It makes sense that you'd feel overwhelmed!
@@ -591,7 +591,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">???</span>
+            <span class="dialogue-name expression-exception-loop">???</span>
             <span class="dialogue-expression">(teehee1)</span>
         </span>
         Considering this is your first loop, and all.
@@ -607,7 +607,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">???</span>
+            <span class="dialogue-name expression-exception-loop">???</span>
             <span class="dialogue-expression">(lol5)</span>
         </span>
         Aw, of course I know, stardust!
@@ -615,7 +615,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">???</span>
+            <span class="dialogue-name expression-exception-loop">???</span>
             <span class="dialogue-expression">(teehee1)</span>
         </span>
         I know about you, I know about your party, about the loops, about that funny silver coin you carry--
@@ -631,7 +631,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">???</span>
+            <span class="dialogue-name expression-exception-loop">???</span>
             <span class="dialogue-expression">(hmmm1)</span>
         </span>
         Oh stars, no need to yell.
@@ -639,7 +639,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">???</span>
+            <span class="dialogue-name expression-exception-loop">???</span>
             <span class="dialogue-expression">(teehee3)</span>
         </span>
         Let's take a deep breath in, and out, okay? Breathe with me, let's go. In...
@@ -659,7 +659,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">???</span>
+            <span class="dialogue-name expression-exception-loop">???</span>
             <span class="dialogue-expression">(well2)</span>
         </span>
         Pheeeeeeeeeee e e e ew.
@@ -667,7 +667,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">???</span>
+            <span class="dialogue-name expression-exception-loop">???</span>
             <span class="dialogue-expression">(happy1)</span>
         </span>
         Alright! Who I am, right?
@@ -675,7 +675,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">???</span>
+            <span class="dialogue-name expression-exception-loop">???</span>
             <span class="dialogue-expression">(well3)</span>
         </span>
         Hm, well, let's see, let's go with...
@@ -685,7 +685,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">???</span>
+            <span class="dialogue-name expression-exception-loop">???</span>
             <span class="dialogue-expression">(lol5)</span>
         </span>
         Loop. Your ally Loop, here to help you with the loops. Easy to remember, right?

--- a/public/rooms/loop/loopfight.html
+++ b/public/rooms/loop/loopfight.html
@@ -920,12 +920,7 @@
     <p class="dialogue-line">
         <span class="dialogue-head">
             <span class="dialogue-name">Loop</span>
-            <span class="dialogue-expression expression-exception">
-                (TS_angry2)
-                <span class="tooltip">
-                    <img src="https://instarsandtime.wiki.gg/images/9/9e/ISAT_Portrait_Siffrin_Angry_2_ACT5.png">
-                </span>
-            </span>
+            <span class="dialogue-expression expression-exception-siffrin">(TS_angry2)</span>
         </span>
         STARS,
     </p>

--- a/public/sasasap/hallwayssap.html
+++ b/public/sasasap/hallwayssap.html
@@ -281,7 +281,7 @@
     <p class="dialogue-line">
         <span class="dialogue-head">
             <span class="dialogue-name">Researcher</span>
-            <span class="dialogue-expression">(reading up1)</span>
+            <span class="dialogue-expression">(readingup1)</span>
         </span>
         What, being frozen in time?
     </p>

--- a/public/sasasap/kingfightsap.html
+++ b/public/sasasap/kingfightsap.html
@@ -536,14 +536,14 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Isabeau</span>
+            <span class="dialogue-name sasasap">Isabeau</span>
         </span>
         Urgh...
     </p>
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Mirabelle</span>
+            <span class="dialogue-name sasasap">Mirabelle</span>
         </span>
         No... not like this... Not like this...!!!
     </p>
@@ -1284,7 +1284,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Isabeau</span>
+            <span class="dialogue-name sasasap">Isabeau</span>
         </span>
         Don't worry about me, Sif!!! Just <i>GO</i>!!!
     </p>
@@ -1362,7 +1362,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Mirabelle</span>
+            <span class="dialogue-name sasasap">Mirabelle</span>
         </span>
         Come and help me!!! Together, we can finish him off!!!
     </p>
@@ -1373,7 +1373,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Mirabelle</span>
+            <span class="dialogue-name sasasap">Mirabelle</span>
         </span>
         This is our chance! Our chance to end everything <i>once and for all</i>!!!
     </p>
@@ -1430,7 +1430,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Isabeau</span>
+            <span class="dialogue-name sasasap">Isabeau</span>
             <span class="dialogue-expression">(fight2)</span>
         </span>
         ...
@@ -1438,7 +1438,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Mirabelle</span>
+            <span class="dialogue-name sasasap">Mirabelle</span>
             <span class="dialogue-expression">(fight2)</span>
         </span>
         ...
@@ -1446,7 +1446,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Odile</span>
+            <span class="dialogue-name sasasap">Odile</span>
             <span class="dialogue-expression">(oof1)</span>
         </span>
         ...
@@ -1454,7 +1454,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Bonnie</span>
+            <span class="dialogue-name sasasap">Bonnie</span>
             <span class="dialogue-expression">(surprised1)</span>
         </span>
         ...
@@ -1472,7 +1472,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Mirabelle</span>
+            <span class="dialogue-name sasasap">Mirabelle</span>
             <span class="dialogue-expression">(determined1)</span>
         </span>
         Did... did we do it?
@@ -1480,7 +1480,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Isabeau</span>
+            <span class="dialogue-name sasasap">Isabeau</span>
             <span class="dialogue-expression">(fight2)</span>
         </span>
         ...
@@ -1488,7 +1488,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Isabeau</span>
+            <span class="dialogue-name sasasap">Isabeau</span>
             <span class="dialogue-expression">(fight1)</span>
         </span>
         ... He's gone...
@@ -1496,7 +1496,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Isabeau</span>
+            <span class="dialogue-name sasasap">Isabeau</span>
             <span class="dialogue-expression">(embarassed2)</span>
         </span>
         We did it...???
@@ -1512,7 +1512,7 @@
     
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Isabeau</span>
+            <span class="dialogue-name sasasap">Isabeau</span>
             <span class="dialogue-expression">(happy1)</span>
         </span>
         Sif, we did it! He's gone! The King is gone!!! Hahahaha!!!
@@ -1538,7 +1538,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Bonnie</span>
+            <span class="dialogue-name sasasap">Bonnie</span>
             <span class="dialogue-expression">(ew2)</span>
         </span>
         Ho...
@@ -1558,7 +1558,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Bonnie</span>
+            <span class="dialogue-name sasasap">Bonnie</span>
             <span class="dialogue-expression">(excited1)</span>
         </span>
         Holy CRAB THAT WAS SCARY!!! WE DID IT? WE DID IT!!!!
@@ -1576,7 +1576,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Odile</span>
+            <span class="dialogue-name sasasap">Odile</span>
             <span class="dialogue-expression">(oof1)</span>
         </span>
         Ha...
@@ -1592,7 +1592,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Odile</span>
+            <span class="dialogue-name sasasap">Odile</span>
             <span class="dialogue-expression">(happy1)</span>
         </span>
         Haha... hahahahaha!!! Oh, it was close for a second there!!!!
@@ -1616,7 +1616,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Mirabelle</span>
+            <span class="dialogue-name sasasap">Mirabelle</span>
             <span class="dialogue-expression">(distressed2)</span>
         </span>
         Oh...
@@ -1624,7 +1624,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Mirabelle</span>
+            <span class="dialogue-name sasasap">Mirabelle</span>
             <span class="dialogue-expression">(cry1)</span>
         </span>
         Oh, what a relief...!
@@ -1632,7 +1632,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Mirabelle</span>
+            <span class="dialogue-name sasasap">Siffrin</span>
             <span class="dialogue-expression">(shock1)</span>
         </span>
         (The savior of Vaugarde, the reason you are all here...) "Mirabelle..."
@@ -1648,7 +1648,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Isabeau</span>
+            <span class="dialogue-name sasasap">Isabeau</span>
             <span class="dialogue-expression">(happy2)</span>
         </span>
         Sif, Sif, Siffrin!!! It's over! We won!!!
@@ -1671,7 +1671,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Isabeau</span>
+            <span class="dialogue-name sasasap">Isabeau</span>
             <span class="dialogue-expression">(happy1)</span>
         </span>
         We won, Sif!!!!! The country's okay, everything's gonna be okay now!!!
@@ -1701,7 +1701,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Mirabelle</span>
+            <span class="dialogue-name sasasap">Mirabelle</span>
             <span class="dialogue-expression">(gentle1)</span>
         </span>
         Oh, Siffrin...
@@ -1709,7 +1709,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Mirabelle</span>
+            <span class="dialogue-name sasasap">Mirabelle</span>
             <span class="dialogue-expression">(smile1)</span>
         </span>
         It'll be okay, Siffrin. We prevailed.
@@ -1717,7 +1717,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Mirabelle</span>
+            <span class="dialogue-name sasasap">Mirabelle</span>
             <span class="dialogue-expression">(smile2)</span>
         </span>
         We'll all be able to go back home!
@@ -1725,7 +1725,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Isabeau</span>
+            <span class="dialogue-name sasasap">Isabeau</span>
             <span class="dialogue-expression">(happy2)</span>
         </span>
         I can't wait to tell my old job friends that I've helped save the country!
@@ -1733,7 +1733,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Bonnie</span>
+            <span class="dialogue-name sasasap">Bonnie</span>
             <span class="dialogue-expression">(excited1)</span>
         </span>
         I gotta go back home and see if my sister's okay!!!
@@ -1741,7 +1741,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Odile</span>
+            <span class="dialogue-name sasasap">Odile</span>
             <span class="dialogue-expression">(sigh1)</span>
         </span>
         Finally, I'll be able to go back to my research.
@@ -1749,7 +1749,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Mirabelle</span>
+            <span class="dialogue-name sasasap">Mirabelle</span>
             <span class="dialogue-expression">(smile1)</span>
         </span>
         Hehehe!
@@ -1757,7 +1757,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Mirabelle</span>
+            <span class="dialogue-name sasasap">Mirabelle</span>
             <span class="dialogue-expression">(gentle1)</span>
         </span>
         See, Siffrin? We'll all be fine now.
@@ -1765,7 +1765,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Mirabelle</span>
+            <span class="dialogue-name sasasap">Mirabelle</span>
             <span class="dialogue-expression">(gentle1)</span>
         </span>
         There's nothing to worry about anymo--
@@ -1821,7 +1821,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Mirabelle</span>
+            <span class="dialogue-name sasasap">Mirabelle</span>
         </span>
         Ah, Siffrin!!!
     </p>
@@ -1836,7 +1836,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Mirabelle</span>
+            <span class="dialogue-name sasasap">Mirabelle</span>
             <span class="dialogue-expression">(determined1)</span>
         </span>
         Huh???
@@ -1844,7 +1844,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Mirabelle</span>
+            <span class="dialogue-name sasasap">Mirabelle</span>
             <span class="dialogue-expression">(awkward1)</span>
         </span>
         Siffrin, were you... were you...
@@ -1852,7 +1852,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Mirabelle</span>
+            <span class="dialogue-name sasasap">Mirabelle</span>
             <span class="dialogue-expression">(awkward2)</span>
         </span>
         TAKING A <i>NAP</i>????!??!
@@ -1860,7 +1860,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Mirabelle</span>
+            <span class="dialogue-name sasasap">Mirabelle</span>
             <span class="dialogue-expression">(wondering1)</span>
         </span>
         I... I suppose that's...
@@ -1868,7 +1868,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Mirabelle</span>
+            <span class="dialogue-name sasasap">Mirabelle</span>
             <span class="dialogue-expression">(smile1)</span>
         </span>
         Yes, you're right! I should follow your lead on this one!
@@ -1876,7 +1876,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Mirabelle</span>
+            <span class="dialogue-name sasasap">Mirabelle</span>
             <span class="dialogue-expression">(smile2)</span>
         </span>
         We'd better get some sleep while we can! Since tomorrow...
@@ -1886,7 +1886,7 @@
 
     <p class="dialogue-line">
         <span class="dialogue-head">
-            <span class="dialogue-name">Mirabelle</span>
+            <span class="dialogue-name sasasap">Mirabelle</span>
             <span class="dialogue-expression">(smile1)</span>
         </span>
         We'll have to fight against the King!

--- a/public/sasasap/lastroom.html
+++ b/public/sasasap/lastroom.html
@@ -353,7 +353,7 @@
     <p class="dialogue-line">
         <span class="dialogue-head">
             <span class="dialogue-name">Researcher</span>
-            <span class="dialogue-expression">(reading_up1)</span>
+            <span class="dialogue-expression">(readingup1)</span>
         </span>
         Oh boy.
     </p>
@@ -2313,7 +2313,7 @@
     <p class="dialogue-line">
         <span class="dialogue-head">
             <span class="dialogue-name">Researcher</span>
-            <span class="dialogue-expression">(reading_up1)</span>
+            <span class="dialogue-expression">(readingup1)</span>
         </span>
         Did I hear someone say "crab"? Siffrin, are you making our dear Housemaiden curse?
     </p>
@@ -3035,7 +3035,7 @@
     <p class="dialogue-line">
         <span class="dialogue-head">
             <span class="dialogue-name">Researcher</span>
-            <span class="dialogue-expression">(reading_up1)</span>
+            <span class="dialogue-expression">(readingup1)</span>
         </span>
         ...
     </p>
@@ -3067,7 +3067,7 @@
     <p class="dialogue-line">
         <span class="dialogue-head">
             <span class="dialogue-name">Researcher</span>
-            <span class="dialogue-expression">(reading_up1)</span>
+            <span class="dialogue-expression">(readingup1)</span>
         </span>
         ...You probably need it.
     </p>


### PR DESCRIPTION
only have loop and siffrin for the "the name doesn't *say* this but it should be [\_\_\_]" expressions right now, which are `expression-exception-loop` for "this should be loop" and `expression-exception-siffrin` for "this should be siffrin"

works the same as the sasasap exceptions and manual exceptions (speaking of which, i changed the twohats exception to a should-be-siffrin exception rather than a manual one. saves having to change an image link in two places later if ever needed)