### PR TITLE
fix ACT 1 ending dead link on act overview page

### DIFF
--- a/public/overview/acts.html
+++ b/public/overview/acts.html
@@ -33,7 +33,7 @@
     <li><a href="/rooms/dormont/meadow.html#act1">ACT 1 Intro</a></li>
     <li><a href="/rooms/dormont/favortree.html#wish">Favor Tree Wish</a></li>
     <li><a href="/rooms/dormont/clocktower.html">Clocktower</a></li>
-    <li><a href="/rooms/floor1/deathcorridor.html#act1">ACT 1 Ending</a></li>
+    <li><a href="rooms/entrance/deathcorridor#act1">ACT 1 Ending</a></li>
 </ul>
 
 <hr>

--- a/public/overview/acts.html
+++ b/public/overview/acts.html
@@ -33,7 +33,7 @@
     <li><a href="/rooms/dormont/meadow.html#act1">ACT 1 Intro</a></li>
     <li><a href="/rooms/dormont/favortree.html#wish">Favor Tree Wish</a></li>
     <li><a href="/rooms/dormont/clocktower.html">Clocktower</a></li>
-    <li><a href="rooms/entrance/deathcorridor#act1">ACT 1 Ending</a></li>
+    <li><a href="/rooms/entrance/deathcorridor#act1">ACT 1 Ending</a></li>
 </ul>
 
 <hr>


### PR DESCRIPTION
commit makes it go to the ACT 1 section, suggest changes if it should lead to the ending bit itself instead (deathcorridor#pancake)